### PR TITLE
Make literal scalars work & also add comparason operators

### DIFF
--- a/src/TakingBroadcastSeriously.jl
+++ b/src/TakingBroadcastSeriously.jl
@@ -11,7 +11,7 @@ end
 unwrap(w::Broadcasted) = w.x
 
 # We must hack each function we want to use with un-fused broadcasting.
-for f in :[sin, cos, +, -, *, /, ^].args
+for f in :[sin, cos, +, -, *, /, ^, <, <=, >, >=, !=, ==].args
   @eval Base.$f(a::Broadcasted...) = Broadcasted(broadcast_($f, unwrap.(a)...))
 
   #sometimes literals "resist" wrapping, so catch them too

--- a/src/TakingBroadcastSeriously.jl
+++ b/src/TakingBroadcastSeriously.jl
@@ -13,6 +13,9 @@ unwrap(w::Broadcasted) = w.x
 # We must hack each function we want to use with un-fused broadcasting.
 for f in :[sin, cos, +, -, *, /, ^].args
   @eval Base.$f(a::Broadcasted...) = Broadcasted(broadcast_($f, unwrap.(a)...))
+
+  #sometimes literals "resist" wrapping, so catch them too
+  @eval Base.$f(a::Broadcasted, b) = Broadcasted(broadcast_($f, unwrap(a), b))
 end
 
 macro unfuse(T)

--- a/src/TakingBroadcastSeriously.jl
+++ b/src/TakingBroadcastSeriously.jl
@@ -16,6 +16,7 @@ for f in :[sin, cos, +, -, *, /, ^].args
 
   #sometimes literals "resist" wrapping, so catch them too
   @eval Base.$f(a::Broadcasted, b) = Broadcasted(broadcast_($f, unwrap(a), b))
+  @eval Base.$f(b, a::Broadcasted) = Broadcasted(broadcast_($f, b, unwrap(a)))
 end
 
 macro unfuse(T)

--- a/src/TakingBroadcastSeriously.jl
+++ b/src/TakingBroadcastSeriously.jl
@@ -1,5 +1,5 @@
 module TakingBroadcastSeriously
-
+import Base: ^
 using Base.Broadcast: broadcast_c, containertype
 
 broadcast_(f, A, Bs...) = broadcast_c(f, containertype(A, Bs...), A, Bs...)
@@ -18,6 +18,9 @@ for f in :[sin, cos, +, -, *, /, ^].args
   @eval Base.$f(a::Broadcasted, b) = Broadcasted(broadcast_($f, unwrap(a), b))
   @eval Base.$f(b, a::Broadcasted) = Broadcasted(broadcast_($f, b, unwrap(a)))
 end
+
+#Avoid ambiguitity with Base
+^(a::Broadcasted, b::Integer) = Broadcasted(broadcast_(^, unwrap(a), b))
 
 macro unfuse(T)
   T = esc(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,11 +26,15 @@ function broadcast_(::typeof(cos), xs::FooArray)
   FooArray(cos.(xs.data))
 end
 
-xs = rand(5)
-xs′ = FooArray(xs)
+@testset "Seriously" begin
+    xs = rand(5)
+    xs′ = FooArray(xs)
 
-@test cos.(sin.(xs)) == cos.(sin.(xs′))
+    @test cos.(sin.(xs)) == cos.(sin.(xs′))
 
-@test blist == [sin, cos]
+    @test blist == [sin, cos]
 
-@test xs.^3.0 == xs′.^3.0
+    @test xs.^3.0 == xs′.^3.0
+    @test 50 .* xs == 50 .* xs′
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,5 +36,5 @@ end
 
     @test xs.^3.0 == xs′.^3.0
     @test 50 .* xs == 50 .* xs′
-
+    @test xs.^3 == xs′.^3
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,8 @@ end
 xs = rand(5)
 xs′ = FooArray(xs)
 
-cos.(sin.(xs)) == cos.(sin.(xs′))
+@test cos.(sin.(xs)) == cos.(sin.(xs′))
 
 @test blist == [sin, cos]
+
+@test xs.^3.0 == xs′.^3.0


### PR DESCRIPTION
I believe this fixes #1 
This is blocking for https://github.com/malmaud/TensorFlow.jl/pull/334

It is mysterious how literal scalars interact with broadcasting.
I think they are jitted into closures that are modified versions of the function that are being broadcast?